### PR TITLE
Fix build errors and warnings

### DIFF
--- a/BodyCentricCubicMesh/Testing/Cxx/CMakeLists.txt
+++ b/BodyCentricCubicMesh/Testing/Cxx/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CLP ${MODULE_NAME})
 
 #-----------------------------------------------------------------------------
 add_executable(${CLP}Test ${CLP}Test.cxx)
-target_link_libraries(${CLP}Test ${CLP}Lib)
+target_link_libraries(${CLP}Test ${CLP}Lib ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES})
 set_target_properties(${CLP}Test PROPERTIES LABELS ${CLP})
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5)
 
 project(CBC3D_I2M_Conversion)
 

--- a/MeshCompression/Testing/Cxx/CMakeLists.txt
+++ b/MeshCompression/Testing/Cxx/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CLP ${MODULE_NAME})
 
 #-----------------------------------------------------------------------------
 add_executable(${CLP}Test ${CLP}Test.cxx)
-target_link_libraries(${CLP}Test ${CLP}Lib)
+target_link_libraries(${CLP}Test ${CLP}Lib ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES})
 set_target_properties(${CLP}Test PROPERTIES LABELS ${CLP})
 
 

--- a/MeshCompression/itkFEMCompressor.h
+++ b/MeshCompression/itkFEMCompressor.h
@@ -410,7 +410,7 @@ protected:
 				nodeId = *pointIdIter;
 				point = pMesh->GetPoint(nodeId);
 
-				for(int i=0; i<MeshDimension; i++)
+				for(unsigned int i=0; i<MeshDimension; i++)
 					pos[i] = point[i];
 
 				if(count==0)

--- a/MeshCompression/itkFEMCompressor.hxx
+++ b/MeshCompression/itkFEMCompressor.hxx
@@ -112,7 +112,7 @@ void FEMCompressor<TInputMesh, TInputImage, TOutputMesh>
 	for(iter = pNodeContainer->Begin(); iter != pNodeContainer->End();  iter++)
 	{
 		pos.SetVnlVector(iter.Value()->GetCoordinates());
-		for(int i=0; i<MeshDimension; i++)
+		for(unsigned int i=0; i<MeshDimension; i++)
 			pt[i] = pos[i];
 
 		pOutputMesh->SetPoint(iter.Index(),pt);
@@ -394,7 +394,7 @@ FEMCompressor< TInputMesh, TInputImage, TOutputMesh >
 
 			// count 0s offsets in each dimension
 			unsigned numberOfZeros = 0;
-			for ( unsigned j = 0; j < MeshDimension; j++ )
+			for ( unsigned int j = 0; j < MeshDimension; j++ )
 			{
 				if ( off[j] == 0 )
 					numberOfZeros++;
@@ -1027,7 +1027,7 @@ void FEMCompressor<TInputMesh, TInputImage, TOutputMesh>
 	// Initialize nodes
 	while(it != meshPoints->End())
 	{
-		for(unsigned i = 0; i < MeshDimension; i++)
+		for(unsigned int i = 0; i < MeshDimension; i++)
 			point[i]= it.Value()[i];
 
 		NodeType::Pointer node = NodeType::New();

--- a/MeshCompression/itkFEMCompressorSolver.hxx
+++ b/MeshCompression/itkFEMCompressorSolver.hxx
@@ -880,8 +880,8 @@ void CompressorSolver<TPixel,VDimension>
 ::AssembleGlobalMatrixFromLandmarksAndMeshMatrices()
  {
 	//std::cout << "Assembling Global Matrix From Landmarks And Mesh Matrices..." << std::endl;
-	this->m_LinearSystem->CopyMatrix( this->m_MeshStiffnessMatrixIndex, this->m_StiffnessMatrixIndex );
-	this->m_LinearSystem->AddMatrixMatrix( this->m_StiffnessMatrixIndex, this->m_LandmarkStiffnessMatrixIndex);
+	this->GetLinearSystemWrapper()->CopyMatrix( this->m_MeshStiffnessMatrixIndex, this->m_StiffnessMatrixIndex );
+	this->GetLinearSystemWrapper()->AddMatrixMatrix( this->m_StiffnessMatrixIndex, this->m_LandmarkStiffnessMatrixIndex);
 }
 
 template <class TPixel,unsigned int VDimension>
@@ -958,7 +958,7 @@ void CompressorSolver<TPixel,VDimension>
 					const int dofm = element->GetDegreeOfFreedom(k * numberOfDOFs + m);
 					const float value = static_cast<float>( barCoor * tradeOff * pointTensorPonderation * (tens(n,m)) * confidence );
 
-					this->m_LinearSystem->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
+					this->GetLinearSystemWrapper()->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
 				}
 			}
 		}
@@ -978,8 +978,8 @@ void CompressorSolver<TPixel,VDimension>
 						const int dofm = element->GetDegreeOfFreedom(j * numberOfDOFs + m);
 						const float value = static_cast<float>( barCoor * tradeOff * pointTensorPonderation * (tens(n, m)) * confidence );
 
-						this->m_LinearSystem->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
-						this->m_LinearSystem->AddMatrixValue(dofm, dofn, value, m_LandmarkStiffnessMatrixIndex);
+						this->GetLinearSystemWrapper()->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
+						this->GetLinearSystemWrapper()->AddMatrixValue(dofm, dofn, value, m_LandmarkStiffnessMatrixIndex);
 
 					}
 				}
@@ -1037,7 +1037,7 @@ void CompressorSolver<TPixel,VDimension>
 				{
 					unsigned nx = element->GetDegreeOfFreedom(nodeId * numberOfDOFs + dofXId);
 					unsigned ny = element->GetDegreeOfFreedom(nodeId * numberOfDOFs + dofYId);
-					nodeTensor[dofXId][dofYId] = this->m_LinearSystem->GetMatrixValue(nx, ny, m_MeshStiffnessMatrixIndex);
+					nodeTensor[dofXId][dofYId] = this->GetLinearSystemWrapper()->GetMatrixValue(nx, ny, m_MeshStiffnessMatrixIndex);
 				}
 			}
 			landmarkTensor += nodeTensor * shape[nodeId];
@@ -1204,11 +1204,11 @@ void CompressorSolver<TPixel,VDimension>
 	std::cout <<  "Printing Forces at : " << fName << std::endl;
 
 	Float val = 0;
-	int NumDofs = this->m_LinearSystem->GetSystemOrder();
+	int NumDofs = this->GetLinearSystemWrapper()->GetSystemOrder();
 	std::cout <<  "Num DOF's : " << NumDofs << std::endl;
 	for( int i = 0; i < NumDofs; i++ )
 	{
-		val = this->m_LinearSystem->GetVectorValue(i,m_ForceIndex);
+		val = this->GetLinearSystemWrapper()->GetVectorValue(i,m_ForceIndex);
 		fprintf(pFile,"%6.8f\n",val);
 	}
 	fclose(pFile);
@@ -1229,12 +1229,12 @@ void CompressorSolver<TPixel,VDimension>
 	std::cout <<  "Printing Solution Displacements at : " << fName << std::endl;
 
 	Float val = 0;
-	int NumDofs = this->m_LinearSystem->GetSystemOrder();
+	int NumDofs = this->GetLinearSystemWrapper()->GetSystemOrder();
 	std::cout <<  "Num DOF's : " << NumDofs << std::endl;
 	for( int i = 0; i < NumDofs; i++ )
 	{
 		// Get the solution displacements
-		val = this->m_LinearSystem->GetSolutionValue(i,m_SolutionIndex);
+		val = this->GetLinearSystemWrapper()->GetSolutionValue(i,m_SolutionIndex);
 		fprintf(pFile,"%10.10f\n",val);
 	}
 	fclose(pFile);

--- a/MeshCompression/itkFEMCompressorSolver.hxx
+++ b/MeshCompression/itkFEMCompressorSolver.hxx
@@ -880,8 +880,8 @@ void CompressorSolver<TPixel,VDimension>
 ::AssembleGlobalMatrixFromLandmarksAndMeshMatrices()
  {
 	//std::cout << "Assembling Global Matrix From Landmarks And Mesh Matrices..." << std::endl;
-	this->m_ls->CopyMatrix( this->m_MeshStiffnessMatrixIndex, this->m_StiffnessMatrixIndex );
-	this->m_ls->AddMatrixMatrix( this->m_StiffnessMatrixIndex, this->m_LandmarkStiffnessMatrixIndex);
+	this->m_LinearSystem->CopyMatrix( this->m_MeshStiffnessMatrixIndex, this->m_StiffnessMatrixIndex );
+	this->m_LinearSystem->AddMatrixMatrix( this->m_StiffnessMatrixIndex, this->m_LandmarkStiffnessMatrixIndex);
 }
 
 template <class TPixel,unsigned int VDimension>
@@ -958,7 +958,7 @@ void CompressorSolver<TPixel,VDimension>
 					const int dofm = element->GetDegreeOfFreedom(k * numberOfDOFs + m);
 					const float value = static_cast<float>( barCoor * tradeOff * pointTensorPonderation * (tens(n,m)) * confidence );
 
-					this->m_ls->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
+					this->m_LinearSystem->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
 				}
 			}
 		}
@@ -978,8 +978,8 @@ void CompressorSolver<TPixel,VDimension>
 						const int dofm = element->GetDegreeOfFreedom(j * numberOfDOFs + m);
 						const float value = static_cast<float>( barCoor * tradeOff * pointTensorPonderation * (tens(n, m)) * confidence );
 
-						this->m_ls->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
-						this->m_ls->AddMatrixValue(dofm, dofn, value, m_LandmarkStiffnessMatrixIndex);
+						this->m_LinearSystem->AddMatrixValue(dofn, dofm, value, m_LandmarkStiffnessMatrixIndex);
+						this->m_LinearSystem->AddMatrixValue(dofm, dofn, value, m_LandmarkStiffnessMatrixIndex);
 
 					}
 				}
@@ -1037,7 +1037,7 @@ void CompressorSolver<TPixel,VDimension>
 				{
 					unsigned nx = element->GetDegreeOfFreedom(nodeId * numberOfDOFs + dofXId);
 					unsigned ny = element->GetDegreeOfFreedom(nodeId * numberOfDOFs + dofYId);
-					nodeTensor[dofXId][dofYId] = this->m_ls->GetMatrixValue(nx, ny, m_MeshStiffnessMatrixIndex);
+					nodeTensor[dofXId][dofYId] = this->m_LinearSystem->GetMatrixValue(nx, ny, m_MeshStiffnessMatrixIndex);
 				}
 			}
 			landmarkTensor += nodeTensor * shape[nodeId];
@@ -1204,11 +1204,11 @@ void CompressorSolver<TPixel,VDimension>
 	std::cout <<  "Printing Forces at : " << fName << std::endl;
 
 	Float val = 0;
-	int NumDofs = this->m_ls->GetSystemOrder();
+	int NumDofs = this->m_LinearSystem->GetSystemOrder();
 	std::cout <<  "Num DOF's : " << NumDofs << std::endl;
 	for( int i = 0; i < NumDofs; i++ )
 	{
-		val = this->m_ls->GetVectorValue(i,m_ForceIndex);
+		val = this->m_LinearSystem->GetVectorValue(i,m_ForceIndex);
 		fprintf(pFile,"%6.8f\n",val);
 	}
 	fclose(pFile);
@@ -1229,12 +1229,12 @@ void CompressorSolver<TPixel,VDimension>
 	std::cout <<  "Printing Solution Displacements at : " << fName << std::endl;
 
 	Float val = 0;
-	int NumDofs = this->m_ls->GetSystemOrder();
+	int NumDofs = this->m_LinearSystem->GetSystemOrder();
 	std::cout <<  "Num DOF's : " << NumDofs << std::endl;
 	for( int i = 0; i < NumDofs; i++ )
 	{
 		// Get the solution displacements
-		val = this->m_ls->GetSolutionValue(i,m_SolutionIndex);
+		val = this->m_LinearSystem->GetSolutionValue(i,m_SolutionIndex);
 		fprintf(pFile,"%10.10f\n",val);
 	}
 	fclose(pFile);


### PR DESCRIPTION
@fdrakopo While testing the recent updates associated with Slicer build system, I ended updating your extension

Please, consider reviewing and testing this set of changes. Worth noting that running the tests locally was conclusive, all tests passed. See report below. 

Ps: Congrats on adding tests :fireworks: 

Ps2: If you have a chance and if possible at all, I wonder if you could use low resolution data in the tests enabled by default. That would speed up the testing which currently takes 468.48s to complete on my 8 core machines. Look like `MeshCompressionTest1` is the outlier. 

In the future, makes sure not to reference ITK ivar, instead prefer using the corresponding accessor method. The ITK community works on maintaining (and mitigating) backward compatibility associated only with the public API and not with the internal private ivar. For reference, see 5d01ada and ada0433.  (cc: @thewtex)

Let us know with you have any questions. The  [Slicer discussion forum](https://discourse.slicer.org) is a good outlet for questions.

As a side note, the migration guide associated with VTK6, VTK7, VTK8, Qt5 and Slicer are now all linked of https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide

Test results:

```
Test project /home/jcfr/Projects/ImageToMeshConversion-build
    Start 1: BodyCentricCubicMeshTest1
1/6 Test #1: BodyCentricCubicMeshTest1 ........   Passed   23.82 sec
    Start 2: BodyCentricCubicMeshTest2
2/6 Test #2: BodyCentricCubicMeshTest2 ........   Passed   15.59 sec
    Start 3: BodyCentricCubicMeshTest3
3/6 Test #3: BodyCentricCubicMeshTest3 ........   Passed   24.74 sec
    Start 4: MeshCompressionTest1
4/6 Test #4: MeshCompressionTest1 .............   Passed  238.83 sec
    Start 5: MeshCompressionTest2
5/6 Test #5: MeshCompressionTest2 .............   Passed   90.31 sec
    Start 6: MeshCompressionTest3
6/6 Test #6: MeshCompressionTest3 .............   Passed   75.19 sec

100% tests passed, 0 tests failed out of 6

Label Time Summary:
BodyCentricCubicMesh    =  64.14 sec (3 tests)
MeshCompression         = 404.33 sec (3 tests)

Total Test time (real) = 468.48 sec

```

Cc: @fedorov @lassoan @pieper